### PR TITLE
Fix searching via the GameBanana search API after a breaking change

### DIFF
--- a/mons/commands/mods.py
+++ b/mons/commands/mods.py
@@ -177,12 +177,12 @@ def search(search: str):
         match = [
             mod
             for mod, data in mod_list.items()
-            if data["GameBananaId"] == item["itemid"]
+            if data["GameBananaId"] == item["GameBananaId"]
         ]
         for m in match:
             echo(m)
         if len(match) < 1:
-            raise click.UsageError("Entry not found: " + str(item["itemid"]))
+            raise click.UsageError("Entry not found: " + str(item["GameBananaId"]))
 
 
 def prompt_mod_selection(options: t.Dict[str, t.Any], max=-1):
@@ -440,7 +440,7 @@ def add(
                 {
                     mod: data
                     for mod, data in mod_list.items()
-                    if data["GameBananaId"] == item["itemid"]
+                    if data["GameBananaId"] == item["GameBananaId"]
                 }
             )
 

--- a/mons/utils.py
+++ b/mons/utils.py
@@ -325,7 +325,7 @@ def search_mods(search: str):
         f"https://max480-random-stuff.appspot.com/celeste/gamebanana-search?q={search}"
     )
     response = urllib.request.urlopen(url)
-    return yaml.safe_load(response.read())
+    return json.loads(response.read())
 
 
 def read_blacklist(path: str):


### PR DESCRIPTION
Depending on if `full=true` was passed or not, the API would send out all mod info _in JSON format_ or just the itemtype/itemid _in YAML format_, which was, uh, pretty dubious. 😅 I removed that behavior, and now the API returns the full info at all times, since Olympus uses that.

 ... I wasn't aware of mons using that as well. 😅 Here is a PR that fixes this: it's just a field name change, and the response being JSON instead of YAML.