### PR TITLE
Change max480-random-stuff.appspot.com to maddie480.ovh

### DIFF
--- a/mons/commands/mods.py
+++ b/mons/commands/mods.py
@@ -384,7 +384,7 @@ def add(
     if random:
         mods = (
             urllib.request.urlopen(
-                "https://max480.ovh/celeste/random-map"
+                "https://maddie480.ovh/celeste/random-map"
             ).url,
         )
 

--- a/mons/commands/mods.py
+++ b/mons/commands/mods.py
@@ -384,7 +384,7 @@ def add(
     if random:
         mods = (
             urllib.request.urlopen(
-                "https://max480-random-stuff.appspot.com/celeste/random-map"
+                "https://max480.ovh/celeste/random-map"
             ).url,
         )
 

--- a/mons/utils.py
+++ b/mons/utils.py
@@ -310,7 +310,7 @@ def get_dependency_graph() -> t.Dict[str, t.Any]:
 
     dependency_graph = yaml.safe_load(
         download_with_progress(
-            "https://max480-random-stuff.appspot.com/celeste/mod_dependency_graph.yaml?format=everestyaml",
+            "https://max480.ovh/celeste/mod_dependency_graph.yaml?format",
             None,
             "Downloading Dependency Graph",
             clear=True,
@@ -322,7 +322,7 @@ def get_dependency_graph() -> t.Dict[str, t.Any]:
 def search_mods(search: str):
     search = urllib.parse.quote_plus(search)
     url = (
-        f"https://max480-random-stuff.appspot.com/celeste/gamebanana-search?q={search}"
+        f"https://max480.ovh/celeste/gamebanana-search?q={search}"
     )
     response = urllib.request.urlopen(url)
     return json.loads(response.read())

--- a/mons/utils.py
+++ b/mons/utils.py
@@ -310,7 +310,7 @@ def get_dependency_graph() -> t.Dict[str, t.Any]:
 
     dependency_graph = yaml.safe_load(
         download_with_progress(
-            "https://max480.ovh/celeste/mod_dependency_graph.yaml",
+            "https://maddie480.ovh/celeste/mod_dependency_graph.yaml",
             None,
             "Downloading Dependency Graph",
             clear=True,
@@ -322,7 +322,7 @@ def get_dependency_graph() -> t.Dict[str, t.Any]:
 def search_mods(search: str):
     search = urllib.parse.quote_plus(search)
     url = (
-        f"https://max480.ovh/celeste/gamebanana-search?q={search}"
+        f"https://maddie480.ovh/celeste/gamebanana-search?q={search}"
     )
     response = urllib.request.urlopen(url)
     return json.loads(response.read())

--- a/mons/utils.py
+++ b/mons/utils.py
@@ -310,7 +310,7 @@ def get_dependency_graph() -> t.Dict[str, t.Any]:
 
     dependency_graph = yaml.safe_load(
         download_with_progress(
-            "https://max480.ovh/celeste/mod_dependency_graph.yaml?format",
+            "https://max480.ovh/celeste/mod_dependency_graph.yaml",
             None,
             "Downloading Dependency Graph",
             clear=True,


### PR DESCRIPTION
The domain name of my APIs changed. The old one redirects to the new one, but we might as well just update the URLs 😅

The `?format=everestyaml` parameter is also not required anymore.