### PR TITLE
Misc fixes

### DIFF
--- a/mons/commands/mods.py
+++ b/mons/commands/mods.py
@@ -1117,7 +1117,7 @@ def resolve(
         "{resolve_count} dependency missing",
         "{resolve_count} dependencies missing",
         len(deps_missing) + len(deps_outdated),
-    ).format(len(deps_missing) + len(deps_outdated))
+    ).format(resolve_count=len(deps_missing) + len(deps_outdated))
     if deps_outdated:
         msg += " or outdated"
     echo(msg)

--- a/mons/modmeta.py
+++ b/mons/modmeta.py
@@ -24,7 +24,7 @@ class ModMeta_Base:
 
     @classmethod
     def _from_dict(cls, data: t.Dict[str, t.Any]):
-        return cls(str(data["Name"]), str(data.get("Version", NOVERSION)))
+        return cls(str(data["Name"]), str(data.get("Version", NOVERSION())))
 
     def __repr__(self) -> str:
         return f"{self.Name}: {self.Version}"

--- a/mons/version.py
+++ b/mons/version.py
@@ -56,6 +56,8 @@ class Version:
         # Special case: Always True if version == 0.0.*
         if self.Major == 0 and self.Minor == 0:
             return True
+        if required.Major == 0 and required.Minor == 0:
+            return True
 
         # Major version, breaking changes, must match.
         if self.Major != required.Major:


### PR DESCRIPTION
format argument:
```
$ mons mods resolve main
error: An unhandled exception has occurred:
error:   KeyError('resolve_count')
error: Use the --debug flag to disable clean exception handling.
```

missing everest version:
```
$ mons mods resolve main
2 dependencies missing
error: Mod 'EverestCore' could not be resolved and is not a valid URL.
error: Mod 'EverestCore' could not be resolved and is not a valid URL.
error: Encountered an error while resolving mods.
error: Encountered an error while resolving mods.
Continue anyways? [y/N]: y
1 mod to install:
  WinterCollab2021Audio: 1.3.0
After this operation, an additional 154.5 MiB disk space will be used
Continue? [Y/n]: n
Aborted!
```
WinterCollab2021Audio will always be considered missing. everest.yaml:
```
- Name: WinterCollab2021Audio
  Version: 1.3.0
  Dependencies:
  - Name: Everest
```
with the fix:
```
$ mons mods resolve main
1 dependency missing
error: Mod 'EverestCore' could not be resolved and is not a valid URL.
error: Mod 'EverestCore' could not be resolved and is not a valid URL.
error: Encountered an error while resolving mods.
error: Encountered an error while resolving mods.
Aborted!
```